### PR TITLE
Url formatter

### DIFF
--- a/src/main/java/org/yesworkflow/save/HttpSaver.java
+++ b/src/main/java/org/yesworkflow/save/HttpSaver.java
@@ -114,7 +114,6 @@ public class HttpSaver implements Saver
 
     private String formatUrl(String url)
     {
-
         if(!url.startsWith("http://") && !url.startsWith("https://"))
             url = "http://" + url;
 

--- a/src/main/java/org/yesworkflow/save/HttpSaver.java
+++ b/src/main/java/org/yesworkflow/save/HttpSaver.java
@@ -15,13 +15,13 @@ public class HttpSaver implements Saver
     IYwSerializer ywSerializer = null;
     IClient client = null;
     Integer workflowId = null;
-    String baseURL = "http://localhost:8000/";
+    String baseUrl = "http://localhost:8000/";
     String username = null;
     String title = "Title";
     String description = "Description";
     String graph = "";
     String model = "";
-    String model_checksum = "";
+    String model_checksum = "temp";
     String recon = "";
     List<String> tags = new ArrayList<String>();
     List<ScriptDto> scripts = null;
@@ -48,9 +48,9 @@ public class HttpSaver implements Saver
 
     public Saver save()
     {
-        client = new YwClient(baseURL, ywSerializer);
+        client = new YwClient(baseUrl, ywSerializer);
 
-        RunDto run = new RunDto.Builder(username, graph, model, model_checksum, recon, scripts)
+        RunDto run = new RunDto.Builder(username, model, model_checksum, graph, recon, scripts)
                                 .setTitle(title)
                                 .setDescription(description)
                                 .setTags(tags)
@@ -87,7 +87,7 @@ public class HttpSaver implements Saver
         switch(key.toLowerCase())
         {
             case "serveraddress":
-                baseURL = (String) value;
+                baseUrl = formatUrl((String) value);
                 break;
             case "username":
                 username = (String) value;
@@ -110,5 +110,17 @@ public class HttpSaver implements Saver
         }
 
         return this;
+    }
+
+    private String formatUrl(String url)
+    {
+
+        if(!url.startsWith("http://") && !url.startsWith("https://"))
+            url = "http://" + url;
+
+        if(!url.endsWith("/"))
+            url = url + "/";
+
+        return url;
     }
 }

--- a/src/main/java/org/yesworkflow/save/HttpSaver.java
+++ b/src/main/java/org/yesworkflow/save/HttpSaver.java
@@ -21,7 +21,7 @@ public class HttpSaver implements Saver
     String description = "Description";
     String graph = "";
     String model = "";
-    String model_checksum = "temp";
+    String modelChecksum = "";
     String recon = "";
     List<String> tags = new ArrayList<String>();
     List<ScriptDto> scripts = null;
@@ -50,7 +50,7 @@ public class HttpSaver implements Saver
     {
         client = new YwClient(baseUrl, ywSerializer);
 
-        RunDto run = new RunDto.Builder(username, model, model_checksum, graph, recon, scripts)
+        RunDto run = new RunDto.Builder(username, model, modelChecksum, graph, recon, scripts)
                                 .setTitle(title)
                                 .setDescription(description)
                                 .setTags(tags)

--- a/src/test/java/org/yesworkflow/save/TestHttpSaver.java
+++ b/src/test/java/org/yesworkflow/save/TestHttpSaver.java
@@ -1,15 +1,9 @@
 package org.yesworkflow.save;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.StatusLine;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.yesworkflow.YesWorkflowTestCase;
 import org.yesworkflow.db.YesWorkflowDB;
@@ -19,19 +13,12 @@ import org.yesworkflow.model.DefaultModeler;
 import org.yesworkflow.model.Modeler;
 import org.yesworkflow.recon.DefaultReconstructor;
 import org.yesworkflow.recon.Reconstructor;
-import org.yesworkflow.save.response.SaveResponse;
-import org.yesworkflow.save.response.UpdateResponse;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class TestHttpSaver extends YesWorkflowTestCase
 {
     private YesWorkflowDB ywdb = null;

--- a/src/test/java/org/yesworkflow/save/TestHttpSaver.java
+++ b/src/test/java/org/yesworkflow/save/TestHttpSaver.java
@@ -9,6 +9,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.yesworkflow.YesWorkflowTestCase;
 import org.yesworkflow.db.YesWorkflowDB;
@@ -25,11 +26,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
 public class TestHttpSaver extends YesWorkflowTestCase
 {
     private YesWorkflowDB ywdb = null;
@@ -76,9 +78,27 @@ public class TestHttpSaver extends YesWorkflowTestCase
     }
 
     @Test
-    public void testSave() throws Exception
+    public void testSaver_FormatUrl() throws Exception
     {
-        //TODO:: Integration Tests and Client Tests
+        IYwSerializer serializer = new JSONSerializer();
+        HttpSaver saver = new HttpSaver(serializer);
 
+        String[][] testData = new String[][]{
+                {"url", "http://url/"},
+                {"url/", "http://url/"},
+                {"http://url", "http://url/"},
+                {"http://url/", "http://url/"},
+                {"https://url", "https://url/"},
+                {"https://url/", "https://url/"},
+                {"", "http://"},
+        };
+
+        for(String[] dataPoint : testData)
+        {
+            saver.configure("serveraddress", dataPoint[0]);
+            assertEquals(String.format("Saver transformed '%s' to  '%s'", dataPoint[0], saver.baseUrl),
+                         dataPoint[1],
+                         saver.baseUrl);
+        }
     }
 }


### PR DESCRIPTION
intended to make configuring a url in the saver easier.

the following is all now valid input for `save.serveraddress`:
+ `http://localhost:8000/`
+ `http://localhost:8000`
+ `localhost:8000/`
+ `localhost:8000`